### PR TITLE
reset historical.nodeSelector default values to {}

### DIFF
--- a/incubator/druid/requirements.lock
+++ b/incubator/druid/requirements.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 3.11.7
-digest: sha256:6e78343dcad8a1a9d6d92236c18357046488ad4ffeec57ea9a08cefa1465d825
-generated: 2019-03-06T15:16:43.198212382-05:00
+digest: sha256:02adcdd4c2454c1e45e1c8ccd2ab8e9d59882ae62b9973478ff3fa172375dfa8
+generated: "2020-03-30T22:29:38.572891+08:00"

--- a/incubator/druid/values.yaml
+++ b/incubator/druid/values.yaml
@@ -160,8 +160,7 @@ historical:
 
   nodeAffinity: {}
 
-  nodeSelector:
-    size: historical
+  nodeSelector: {}
 
   tolerations: []
 


### PR DESCRIPTION
hello guys, I think setting `nodeSelector` = `{size: historical}` as default value will make historical workload find no node matched the selector to run itself.
```
  nodeSelector:
    size: historical
```
we should set it `{}` by default.
It must be the crucial issue to make e2e test failed.
